### PR TITLE
peer dependencies for axios auth refresh should also match dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "nock": "11.7.0"
       },
       "peerDependencies": {
-        "axios-auth-refresh": "3.0.0",
+        "axios-auth-refresh": "3.1.0",
         "form-data": "3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "form-data": "3.0.0"
   },
   "peerDependencies": {
-    "axios-auth-refresh": "3.0.0",
+    "axios-auth-refresh": "3.1.0",
     "form-data": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
axios .20 is the latest version as a supported requirement for axios auth refresh -- this package uses ~.21 so we need to bump peer dependency version