### PR TITLE
st-6712: new setCustomHeader method and test coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,10 @@ const Servicetrade = (options) => {
             request.defaults.headers.Authorization = `Bearer ${bearerToken}`;
         },
 
+        setCustomHeader: (key, value) => {
+            request.defaults.headers[key] = value;
+        },
+
         login: async (username, password) => {
             let auth = {
                 username: username || options.username,

--- a/test/index.js
+++ b/test/index.js
@@ -351,3 +351,52 @@ describe('check userAgent header', function() {
         await ST.delete(`/job/100`);
     });
 });
+
+describe('setCustomHeader tests', function() {
+    it('test setCustomHeader success', async function() {
+        nock('https://test.host.com')
+            .delete(`/api/job/100`)
+            .matchHeader('X-Custom-Header', 'customValue')
+            .reply(200, {});
+
+        const ST = Servicetrade(testOptions);
+        ST.setCustomHeader('X-Custom-Header', 'customValue');
+        await ST.delete(`/job/100`);
+    });
+
+    it('test setCustomHeader with multiple headers', async function() {
+        nock('https://test.host.com')
+            .delete(`/api/job/100`)
+            .matchHeader('X-API-Key', 'apiKey123')
+            .matchHeader('X-Client-Version', '1.0.0')
+            .reply(200, {});
+
+        const ST = Servicetrade(testOptions);
+        ST.setCustomHeader('X-API-Key', 'apiKey123');
+        ST.setCustomHeader('X-Client-Version', '1.0.0');
+        await ST.delete(`/job/100`);
+    });
+
+    it('test setCustomHeader overwrites existing header', async function() {
+        nock('https://test.host.com')
+            .delete(`/api/job/100`)
+            .matchHeader('X-Custom-Header', 'newValue')
+            .reply(200, {});
+
+        const ST = Servicetrade(testOptions);
+        ST.setCustomHeader('X-Custom-Header', 'originalValue');
+        ST.setCustomHeader('X-Custom-Header', 'newValue');
+        await ST.delete(`/job/100`);
+    });
+
+    it('test setCustomHeader with empty value', async function() {
+        nock('https://test.host.com')
+            .delete(`/api/job/100`)
+            .matchHeader('X-Empty-Header', '')
+            .reply(200, {});
+
+        const ST = Servicetrade(testOptions);
+        ST.setCustomHeader('X-Empty-Header', '');
+        await ST.delete(`/job/100`);
+    });
+});


### PR DESCRIPTION
# [ST-6712](https://servicetrade.atlassian.net/browse/ST-6712): Add setCustomHeader function with comprehensive tests

**Summary**: Added a new `setCustomHeader` function to the Servicetrade client library that allows users to set custom HTTP headers on requests. The implementation includes comprehensive test coverage with 4 test cases covering basic functionality, multiple headers, header overwriting, and edge cases.

## File-by-file changes:

### ~/index.js
- **Added**: `setCustomHeader(key, value)` function that allows setting arbitrary custom headers on the axios request instance
- **Impact**: Provides flexibility for users to add custom headers like API keys, client versions, or other authentication headers to their requests

### ~/test/index.js
- **Added**: Complete test suite for `setCustomHeader` function with 4 comprehensive test cases
- **Added**: Tests for basic functionality, multiple headers, header overwriting, and empty value edge cases
- **Impact**: Ensures the new functionality works correctly and maintains backward compatibility with existing code

[ST-6712]: https://servicetrade.atlassian.net/browse/ST-6712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ